### PR TITLE
Addressed memory and performance issues

### DIFF
--- a/src/main/scala/com/massivedatascience/clusterer/BasicPointOps.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/BasicPointOps.scala
@@ -181,10 +181,9 @@ object DiscreteDenseKLPointOps extends BasicPointOps(NaturalKLDivergence)
  */
 object DiscreteDenseSmoothedKLPointOps extends BasicPointOps(NaturalKLDivergence) {
 
-  override def vectorToPoint(inh: Vector): BregmanPoint = {
-    val embedded: Vector = embed(inh)
-    val weight = embedded.toArray.sum
-    new BregmanPoint(asInhomogeneous(embedded, weight), embedded.toArray.sum, divergence.F(embedded, weight))
+  override def vectorToPoint(h: Vector): BregmanPoint = {
+    val weight = h.toArray.sum
+    new BregmanPoint(h, weight, divergence.F(h, weight), true)
   }
 
   override def toCenter(v: WeightedVector): BregmanCenter = {

--- a/src/main/scala/com/massivedatascience/clusterer/BasicPointOps.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/BasicPointOps.scala
@@ -25,7 +25,7 @@ case class BasicPointOps(
   clusterFactory: ClusterFactory = DenseClusterFactory,
   embedding: Embedding = IdentityEmbedding) extends BregmanPointOps {
 
-  val weightThreshold = 1e-4
+  @inline val weightThreshold = 1e-4
   val distanceThreshold = 1e-8
 
   def getCentroid = clusterFactory.getCentroid

--- a/src/main/scala/com/massivedatascience/clusterer/BasicPointOps.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/BasicPointOps.scala
@@ -53,14 +53,9 @@ case class BasicPointOps(
     }
   }
 
-  def homogeneousToPoint(h: Vector, weight: Double): BregmanPoint = {
-    val embedded = embed(asInhomogeneous(h, weight))
-    new BregmanPoint(embedded, weight, divergence.F(embedded))
-  }
-
-  def inhomogeneousToPoint(inh: Vector, weight: Double): BregmanPoint = {
+  def vectorToPoint(inh: Vector): BregmanPoint = {
     val embedded = embed(inh)
-    new BregmanPoint(embedded, weight, divergence.F(embedded))
+    new BregmanPoint(embedded, 1.0, divergence.F(embedded))
   }
 
   def toCenter(v: WeightedVector): BregmanCenter = {
@@ -85,8 +80,8 @@ class DelegatedPointOps(ops: BregmanPointOps, embedding: Embedding) extends Breg
   def getCentroid = ops.getCentroid
   def distance(p: BregmanPoint, c: BregmanCenter) = ops.distance(p,c)
   def toCenter(v: WeightedVector) = ops.toCenter(v)
-  def inhomogeneousToPoint(v: Vector, weight: Double) = ops. inhomogeneousToPoint(v,weight)
-  def homogeneousToPoint(v: Vector, weight: Double) = ops.homogeneousToPoint(v,weight)
+
+  def vectorToPoint(v: Vector) = ops.vectorToPoint(v)
   def centerMoved(v: BregmanPoint, w: BregmanCenter) = ops.centerMoved(v,w)
   def toPoint(v: WeightedVector) = ops.toPoint(v)
 }
@@ -185,6 +180,12 @@ object DiscreteDenseKLPointOps extends BasicPointOps(NaturalKLDivergence)
  *
  */
 object DiscreteDenseSmoothedKLPointOps extends BasicPointOps(NaturalKLDivergence) {
+
+  override def vectorToPoint(inh: Vector): BregmanPoint = {
+    val embedded = embed(inh)
+    new BregmanPoint(embedded, embedded.toArray.sum, divergence.F(embedded))
+  }
+
   override def toCenter(v: WeightedVector): BregmanCenter = {
     val h = add(v.homogeneous, 1.0)
     val w = v.weight + v.homogeneous.size

--- a/src/main/scala/com/massivedatascience/clusterer/BasicPointOps.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/BasicPointOps.scala
@@ -110,7 +110,7 @@ object DenseSquaredEuclideanPointOps extends BasicPointOps()
 /**
  * Implements Squared Euclidean distance on sparse vectors in R ** n
  */
-object SparseSquaredEuclideanPointOps extends BasicPointOps(clusterFactory = SparseClusterFactory)
+object SparseSquaredEuclideanPointOps extends BasicPointOps(clusterFactory = DenseClusterFactory)
 
 /**
  * Implements Squared Euclidean distance on sparse vectors in R ** n by
@@ -145,7 +145,7 @@ object ItakuraSaitoPointOps extends BasicPointOps(new ItakuraSaitoDivergence(Gen
  * Also, with sparse data, the centroid can be of high dimension.  To address this, we limit the
  * density of the centroid by dropping low frequency entries in the SparseCentroidProvider
  */
-object SparseRealKLPointOps extends BasicPointOps(RealKLDivergence, SparseClusterFactory) {
+object SparseRealKLPointOps extends BasicPointOps(RealKLDivergence, DenseClusterFactory) {
     /**
    * Smooth the center using a variant Laplacian smoothing.
    *

--- a/src/main/scala/com/massivedatascience/clusterer/BasicPointOps.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/BasicPointOps.scala
@@ -182,8 +182,9 @@ object DiscreteDenseKLPointOps extends BasicPointOps(NaturalKLDivergence)
 object DiscreteDenseSmoothedKLPointOps extends BasicPointOps(NaturalKLDivergence) {
 
   override def vectorToPoint(inh: Vector): BregmanPoint = {
-    val embedded = embed(inh)
-    new BregmanPoint(embedded, embedded.toArray.sum, divergence.F(embedded))
+    val embedded: Vector = embed(inh)
+    val weight = embedded.toArray.sum
+    new BregmanPoint(asInhomogeneous(embedded, weight), embedded.toArray.sum, divergence.F(embedded, weight))
   }
 
   override def toCenter(v: WeightedVector): BregmanCenter = {

--- a/src/main/scala/com/massivedatascience/clusterer/BasicPointOps.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/BasicPointOps.scala
@@ -167,6 +167,9 @@ object SparseRealKLPointOps extends BasicPointOps(RealKLDivergence, SparseCluste
   }
 }
 
+
+object DiscreteDenseSimplexSmoothedKLPointOps extends BasicPointOps(NaturalKullbackLeiblerSimplexDivergence)
+
 /**
  * Implements the Kullback-Leibler divergence for dense points are in N+ ** n,
  * i.e. the entries in each vector are positive integers.

--- a/src/main/scala/com/massivedatascience/clusterer/BregmanDivergence.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/BregmanDivergence.scala
@@ -133,7 +133,7 @@ class KullbackLeiblerSimplexDivergence(logFunc: HasLog) extends BregmanDivergenc
 
 object RealKullbackLeiblerSimplexDivergence extends KullbackLeiblerSimplexDivergence(GeneralLog)
 
-object NaturalKullbackLeiblerSimplexDivergence extends KullbackLeiblerSimplexDivergence(GeneralLog)
+object NaturalKullbackLeiblerSimplexDivergence extends KullbackLeiblerSimplexDivergence(DiscreteLog)
 
 /**
  * The generalized Kullback-Leibler divergence is defined on points on R+ ** n
@@ -164,7 +164,7 @@ class KullbackLeiblerDivergence(logFunc: HasLog) extends BregmanDivergence {
 
 object RealKLDivergence extends KullbackLeiblerDivergence(GeneralLog)
 
-object NaturalKLDivergence extends KullbackLeiblerDivergence(GeneralLog)
+object NaturalKLDivergence extends KullbackLeiblerDivergence(DiscreteLog)
 
 
 /**

--- a/src/main/scala/com/massivedatascience/clusterer/BregmanDivergence.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/BregmanDivergence.scala
@@ -133,7 +133,7 @@ class KullbackLeiblerSimplexDivergence(logFunc: HasLog) extends BregmanDivergenc
 
 object RealKullbackLeiblerSimplexDivergence extends KullbackLeiblerSimplexDivergence(GeneralLog)
 
-object NaturalKullbackLeiblerSimplexDivergence extends KullbackLeiblerSimplexDivergence(DiscreteLog)
+object NaturalKullbackLeiblerSimplexDivergence extends KullbackLeiblerSimplexDivergence(GeneralLog)
 
 /**
  * The generalized Kullback-Leibler divergence is defined on points on R+ ** n
@@ -164,7 +164,7 @@ class KullbackLeiblerDivergence(logFunc: HasLog) extends BregmanDivergence {
 
 object RealKLDivergence extends KullbackLeiblerDivergence(GeneralLog)
 
-object NaturalKLDivergence extends KullbackLeiblerDivergence(DiscreteLog)
+object NaturalKLDivergence extends KullbackLeiblerDivergence(GeneralLog)
 
 
 /**

--- a/src/main/scala/com/massivedatascience/clusterer/ClusterFactory.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ClusterFactory.scala
@@ -203,11 +203,3 @@ trait LateCentroid extends MutableWeightedVector with Serializable {
 object DenseClusterFactory extends ClusterFactory {
   def getCentroid: MutableWeightedVector = new EagerCentroid
 }
-
-object SparseClusterFactory extends ClusterFactory {
-  def getCentroid: MutableWeightedVector = new LateCentroid with FullCollector
-}
-
-object SparseTopKClusterFactory extends ClusterFactory {
-  def getCentroid: MutableWeightedVector = new LateCentroid with TopKCollector
-}

--- a/src/main/scala/com/massivedatascience/clusterer/ClusterFactory.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ClusterFactory.scala
@@ -43,8 +43,6 @@ class EagerCentroid extends MutableWeightedVector with Serializable {
 
   def inhomogeneous = asInhomogeneous
 
-  def isEmpty = weight == 0.0
-
   private var raw: Vector = empty
 
   var weight: Double = 0.0
@@ -62,7 +60,8 @@ class EagerCentroid extends MutableWeightedVector with Serializable {
    */
   private def add(r: Vector, w: Double, direction: Double): this.type = {
     if (w > 0.0) {
-      if (weight == 0.0) {
+      if (raw == empty) {
+        assert(r != empty)
         raw = r.copy
         weight = w
       } else {

--- a/src/main/scala/com/massivedatascience/clusterer/ClusterFactory.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ClusterFactory.scala
@@ -17,14 +17,9 @@
 
 package com.massivedatascience.clusterer
 
-import java.util.Comparator
-
 import com.massivedatascience.clusterer.util.BLAS._
-import org.apache.spark.mllib.linalg.{Vectors, Vector}
-import com.google.common.collect.MinMaxPriorityQueue
+import org.apache.spark.mllib.linalg.Vector
 
-
-import scala.collection.mutable.ArrayBuffer
 
 /**
  * K-Means algorithms need a method to construct a median or centroid value.
@@ -73,131 +68,6 @@ class EagerCentroid extends MutableWeightedVector with Serializable {
   }
 }
 
-
-trait Collector {
-  def add(index: Int, value: Double): Unit
-  def result(size: Int): Vector
-}
-
-trait FullCollector extends Collector {
-  val indices = new ArrayBuffer[Int]
-  val values = new ArrayBuffer[Double]
-
-  @inline
-  def add(index: Int, value: Double) = {
-    indices += index
-    values += value
-  }
-
-  def result(size: Int): Vector = Vectors.sparse(size, indices.toArray, values.toArray)
-}
-
-
-/**
- * Retains only the top k most heavily weighted items
- *
- * Note: this collector is not associative!
- */
-trait TopKCollector extends Collector {
-
-  import com.google.common.collect.MinMaxPriorityQueue
-
-  private[this] val heap: MinMaxPriorityQueue[(Int, Double)] = MinMaxPriorityQueue.orderedBy(
-    new Comparator[(Int, Double)]() {
-      def compare(x: (Int, Double), y: (Int, Double)): Int = (y._2 - x._2).toInt
-    }
-  ).maximumSize(numberToRetain).create()
-
-  def numberToRetain: Int = 128
-
-  @inline
-  def add(index: Int, value: Double) = {
-    heap.add((index, value))
-    println( s"added $index $value")
-  }
-
-  def result(size: Int): Vector = {
-    Vectors.sparse(size, heap.toArray[(Int, Double)](new Array[(Int, Double)](heap.size())))
-  }
-}
-
-/**
- * Implements a centroid where the points are assumed to be sparse.
- *
- * The calculation of the centroid is deferred until all points are added to the
- * cluster. When the calculation is performed, a priority queue is used to sort the entries
- * by index.
- *
- */
-trait LateCentroid extends MutableWeightedVector with Serializable {
-  this: Collector =>
-
-  import com.massivedatascience.clusterer.RichVector
-
-  final val empty = Vectors.zeros(1)
-  private[this] val container = new ArrayBuffer[VectorIterator]()
-  var weight: Double = 0.0
-
-  override lazy val homogeneous = asHomogeneous
-
-  override def asHomogeneous = {
-    if (container.isEmpty) {
-      empty
-    } else if (container.size == 1) {
-      container.remove(0).underlying
-    } else {
-      val pq: MinMaxPriorityQueue[VectorIterator] = MinMaxPriorityQueue.orderedBy[VectorIterator](
-        new Comparator[VectorIterator]() {
-          def compare(x: VectorIterator, y: VectorIterator): Int = x.index - y.index
-        }
-      ).create()
-
-      for( c <- container) pq.add(c)
-      val peek = pq.peek()
-      val size = peek.underlying.size
-      var total = 0.0
-      var lastIndex = peek.index
-      while (pq.size > 0) {
-        val head = pq.remove()
-        val index = head.index
-        val value = head.value
-        if (index == lastIndex) {
-          total = total + value
-        } else {
-          add(lastIndex, total)
-          total = value
-          lastIndex = index
-        }
-        head.advance()
-
-        if (head.hasNext) pq.add(head)
-      }
-      if (total != 0.0) add(lastIndex, total)
-      result(size)
-    }
-  }
-
-  def inhomogeneous = asInhomogeneous
-
-  def isEmpty = weight == 0.0
-
-  def add(p: WeightedVector): this.type = {
-    if (p.weight > 0.0) {
-      val iterator = p.homogeneous.iterator
-      container += iterator
-      weight = weight + p.weight
-    }
-    this
-  }
-
-  def sub(p: WeightedVector): this.type = {
-    if (p.weight > 0.0) {
-      container += p.homogeneous.negativeIterator
-      weight = weight - p.weight
-    }
-    this
-  }
-}
 
 object DenseClusterFactory extends ClusterFactory {
   def getCentroid: MutableWeightedVector = new EagerCentroid

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -119,7 +119,7 @@ class ColumnTrackingKMeans(
      */
     def initialAssignments(points: RDD[BregmanPoint], centers: Array[CenterWithHistory]) = {
       require(points.getStorageLevel.useMemory)
-      points.map(pt => bestAssignment(pt, 0, centers)).setName("initial assignments").persist(StorageLevel.MEMORY_ONLY_SER)
+      points.map(pt => bestAssignment(pt, 0, centers)).setName("initial assignments").persist(StorageLevel.MEMORY_ONLY)
     }
 
 
@@ -152,7 +152,7 @@ class ColumnTrackingKMeans(
           }
       }
       bcCenters.unpersist()
-      currentAssignments.setName(s"assignments round $round").persist(StorageLevel.MEMORY_ONLY_SER)
+      currentAssignments.setName(s"assignments round $round").persist(StorageLevel.MEMORY_ONLY)
     }
 
     /**

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -177,6 +177,8 @@ class ColumnTrackingKMeans(
       if (addOnly) {
         val results = getCompleteCentroids(points, currentAssignments, previousCenters.length)
         results.foreach { case (index, location) =>
+          val change = location.asImmutable
+          logInfo(s"$index change is $change")
           currentCenters(index) = CenterWithHistory(pointOps.toCenter(location.asImmutable), index, round)
         }
       } else {

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -286,9 +286,8 @@ class ColumnTrackingKMeans(
         var i = 0
         while (y.hasNext && x.hasNext) {
           val point = x.next()
-          val assignment = y.next()
-          if (assignment.cluster != -1) {
-            val index = assignment.cluster
+          val index = y.next().cluster
+          if (index != -1) {
             if (centroids(index) == null) {
               centroids(index) = pointOps.getCentroid
               indexBuffer += index

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -223,22 +223,17 @@ class ColumnTrackingKMeans(
       stats.unassignedPoints.setValue(0)
       stats.improvement.setValue(0)
       stats.newlyAssignedPoints.setValue(0)
-      currentAssignments.zipPartitions(previousAssignments) { case (c, p) =>
-        while (c.hasNext && p.hasNext) {
-          val current = c.next()
-          val previous = p.next()
-          if (current.isAssigned) {
-            if (previous.isAssigned) {
-              stats.improvement.add(previous.distance - current.distance)
-              if (current.cluster != previous.cluster) stats.reassignedPoints.add(1)
-            } else {
-              stats.newlyAssignedPoints.add(1)
-            }
+      currentAssignments.zip(previousAssignments).foreach { case (current, previous) =>
+        if (current.isAssigned) {
+          if (previous.isAssigned) {
+            stats.improvement.add(previous.distance - current.distance)
+            if (current.cluster != previous.cluster) stats.reassignedPoints.add(1)
           } else {
-            stats.unassignedPoints.add(1)
+            stats.newlyAssignedPoints.add(1)
           }
+        } else {
+          stats.unassignedPoints.add(1)
         }
-        null
       }
 
       val clusterCounts = countByCluster(currentAssignments)

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -71,7 +71,7 @@ object ColumnTrackingKMeans {
  *
  *
  * @param updateRate for stochastic sampling, the percentage of points to update on each round
- * @param terminationCondition when to terminate the clusering
+ * @param terminationCondition when to terminate the clustering
  */
 class ColumnTrackingKMeans(
   updateRate: Double = 1.0,

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -175,12 +175,12 @@ class ColumnTrackingKMeans(
 
       val currentCenters = previousCenters.clone()
       if (addOnly) {
-        val results = getStochasticCentroidChanges(points, currentAssignments)
+        val results = getCompleteCentroids(points, currentAssignments)
         results.foreach { case (index, location) =>
           currentCenters(index) = CenterWithHistory(pointOps.toCenter(location.asImmutable), index, round)
         }
       } else {
-        val changes = getExactCentroidChanges(points, currentAssignments, previousAssignments)
+        val changes = getCentroidChanges(points, currentAssignments, previousAssignments)
         changes.foreach { case (index, delta) =>
           val c = currentCenters(index)
           val oldPosition = pointOps.toPoint(c.center)
@@ -254,17 +254,16 @@ class ColumnTrackingKMeans(
     /**
      * Identify cluster changes.
      *
-     * Create an array of the changes per cluster.  Some clusters may not have changes.  They will
-     * not be represented in the change set.
+     * Create a map of the CHANGES per cluster.  Some clusters may not have changes.  They will
+     * not be represented in the change set.  The changes must be added to the previous cluster
+     * position.  This method does not do that.
      *
      * @param currentAssignments current assignments
      * @param previousAssignments previous assignments
 
      * @return changes to cluster position
-
-
-
-    def getExactCentroidChanges(
+     */
+    def getCentroidChanges(
       points: RDD[BregmanPoint],
       currentAssignments: RDD[Assignment],
       previousAssignments: RDD[Assignment]): Map[Int, MutableWeightedVector] = {
@@ -286,69 +285,19 @@ class ColumnTrackingKMeans(
         if (curr.cluster != prev.cluster) curr.cluster else -1
       }
     }
-     */
 
-
-    def getStochasticCentroidChanges(
+    def getCompleteCentroids(
       points: RDD[BregmanPoint],
-      assignments: RDD[Assignment]): Map[Int, MutableWeightedVector] =
+      assignments: RDD[Assignment]): Map[Int, MutableWeightedVector] = {
+
+      require(points.getStorageLevel.useMemory)
+      require(assignments.getStorageLevel.useMemory)
 
       points.zip(assignments).filter(_._2.isAssigned).map { case (o, p) =>
         (p.cluster, o)
       }.aggregateByKey(pointOps.getCentroid)(_.add(_), _.add(_)).collectAsMap()
-
-
-    def getExactCentroidChanges(
-      points: RDD[BregmanPoint],
-      currentAssignments: RDD[Assignment],
-      previousAssignments: RDD[Assignment]): Array[(Int, MutableWeightedVector)] = {
-
-      require(points.getStorageLevel.useMemory)
-      require(currentAssignments.getStorageLevel.useMemory)
-      require(previousAssignments.getStorageLevel.useMemory)
-
-      val changes = currentAssignments.zip(previousAssignments).map { case (curr, prev) =>
-        (curr.cluster, prev.cluster)
-      }.setName("changes").cache()
-
-      val results = points.zip(changes).mapPartitions { pts =>
-        val buffer = new ArrayBuffer[(Int, CentroidChange)]
-        for ((point, (add, sub)) <- pts) {
-          if (add != sub) {
-            if (add >= 0) buffer.append((add, Add(point)))
-            if (sub >= 0) buffer.append((sub, Sub(point)))
-          }
-        }
-        logInfo(s"buffer size ${buffer.size}")
-        buffer.iterator
-      }.aggregateByKey(pointOps.getCentroid)(
-          (x, y) => y match {
-            case Add(p) => x.add(p)
-            case Sub(p) => x.sub(p)
-          },
-          (x, y) => x.add(y)
-        ).collect()
-
-      changes.unpersist()
-      results
     }
 
-    /*
-
-      def getStochasticCentroidChanges(
-        points: RDD[BregmanPoint],
-        assignments: RDD[Assignment]): Array[(Int, MutableWeightedVector)] = {
-
-        require(points.getStorageLevel.useMemory)
-        require(assignments.getStorageLevel.useMemory)
-
-        points.zip(assignments).filter(_._2.isAssigned).map { case (o, p) =>
-          (p.cluster, o)
-        }.aggregateByKey(pointOps.getCentroid)(_.add(_), _.add(_)).collect()
-
-      }
-
-  */
 
     /**
      * Find the closest cluster from a given set of clusters

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -324,8 +324,12 @@ class ColumnTrackingKMeans(
             centroids(index).add(point)
           }
         }
-        indexBuffer.result().map(index => (index, centroids(index))).iterator
-      }.reduceByKey((x, y) => x.add(y))
+        assert(y.hasNext == x.hasNext)
+
+        val changedClusters = indexBuffer.result()
+        logInfo(s"number of clusters changed = ${changedClusters.length}")
+        changedClusters.map(index => (index, centroids(index))).iterator
+      }.reduceByKey(_.add(_))
     }
 
 

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -34,10 +34,6 @@ object ColumnTrackingKMeans {
 
   private[clusterer] sealed trait CentroidChange
 
-  private[clusterer] case class Add(point: BregmanPoint) extends CentroidChange
-
-  private[clusterer] case class Sub(point: BregmanPoint) extends CentroidChange
-
   private[clusterer] case class PointWithDistance(point: BregmanPoint,
     assignment: Assignment, dist: Double)
 

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -142,7 +142,7 @@ class ColumnTrackingKMeans(
             else reassignment(point, current, round, centers)
           }
       }
-      bcCenters.unpersist(blocking = false)
+      bcCenters.unpersist(blocking = true)
       currentAssignments.setName(s"assignments round $round").cache()
     }
 
@@ -407,7 +407,7 @@ class ColumnTrackingKMeans(
       do {
         val previousCenters = centers
         centers = updatedCenters(round, assignments, previousAssignments, previousCenters)
-        previousAssignments.unpersist(blocking = false)
+        previousAssignments.unpersist(blocking = true)
         previousAssignments = assignments
         assignments = updatedAssignments(round, previousAssignments, centers)
         terminate = shouldTerminate(round, centers, previousCenters, assignments, previousAssignments)

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -142,7 +142,7 @@ class ColumnTrackingKMeans(
             else reassignment(point, current, round, centers)
           }
       }
-      bcCenters.unpersist(blocking = true)
+      bcCenters.unpersist(blocking = false)
       currentAssignments.setName(s"assignments round $round").cache()
     }
 
@@ -394,7 +394,7 @@ class ColumnTrackingKMeans(
           }
         }
       }.reduceByKeyLocally { (x, y) => if (x.dist < y.dist) x else y}
-      bcCenters.unpersist(blocking = true)
+      bcCenters.unpersist(blocking = false)
       result
     }
 
@@ -420,7 +420,7 @@ class ColumnTrackingKMeans(
       previousAssignments: RDD[Assignment]): RDD[Assignment] = {
 
       val newCenters = updatedCenters(round, assignments, previousAssignments, centers)
-      previousAssignments.unpersist(blocking = true)
+      previousAssignments.unpersist(blocking = false)
       val newAssignments = updatedAssignments(round, assignments, newCenters)
       val terminate = shouldTerminate(round, newCenters, centers, newAssignments, assignments)
       if (terminate) newAssignments else lloyds(round + 1, newCenters, newAssignments, assignments)
@@ -434,7 +434,7 @@ class ColumnTrackingKMeans(
     points.unpersist(blocking = false)
     val (d, centers, assignments) = candidates.minBy(_._1)
     val best = (d, centers, Some(assignments.map(x => (x.cluster, x.distance)).cache()))
-    for ((_, _, a) <- candidates) a.unpersist(blocking = true)
+    for ((_, _, a) <- candidates) a.unpersist(blocking = false)
     best
   }
 

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -21,6 +21,7 @@ package com.massivedatascience.clusterer
 import com.massivedatascience.clusterer.util.XORShiftRandom
 import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
+import org.apache.spark.storage.StorageLevel
 
 import scala.annotation.tailrec
 import scala.collection.Map
@@ -118,7 +119,7 @@ class ColumnTrackingKMeans(
      */
     def initialAssignments(points: RDD[BregmanPoint], centers: Array[CenterWithHistory]) = {
       require(points.getStorageLevel.useMemory)
-      points.map(pt => bestAssignment(pt, 0, centers)).setName("initial assignments").persist()
+      points.map(pt => bestAssignment(pt, 0, centers)).setName("initial assignments").persist(StorageLevel.MEMORY_ONLY_SER)
     }
 
 
@@ -151,7 +152,7 @@ class ColumnTrackingKMeans(
           }
       }
       bcCenters.unpersist()
-      currentAssignments.setName(s"assignments round $round").persist()
+      currentAssignments.setName(s"assignments round $round").persist(StorageLevel.MEMORY_ONLY_SER)
     }
 
     /**

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -80,6 +80,8 @@ class ColumnTrackingKMeans(
 
   import ColumnTrackingKMeans._
 
+  val addOnly = true
+
   /**
    * count number of points assigned to each cluster
    *
@@ -162,7 +164,7 @@ class ColumnTrackingKMeans(
       previousCenters: Array[CenterWithHistory]): Array[CenterWithHistory] = {
 
       val currentCenters = previousCenters.clone()
-      if (updateRate < 1.0) {
+      if (addOnly) {
         val results = getStochasticCentroidChanges(points, currentAssignments)
         results.foreach { case (index, location) =>
           currentCenters(index) = CenterWithHistory(pointOps.toCenter(location.asImmutable), index, round)

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -80,7 +80,7 @@ class ColumnTrackingKMeans(
 
   import ColumnTrackingKMeans._
 
-  val addOnly = false
+  val addOnly = true
 
   /**
    * count number of points assigned to each cluster

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -323,28 +323,21 @@ class ColumnTrackingKMeans(
           val indexBuffer = new mutable.ArrayBuilder.ofInt
           indexBuffer.sizeHint(numCenters)
 
-          @inline def initialize(index: Int) = {
+          @inline def centroidAt(index: Int): MutableWeightedVector = {
             if (centroids(index) == null) {
               centroids(index) = pointOps.getCentroid
               indexBuffer += index
             }
+            centroids(index)
           }
 
           while (z.hasNext && y.hasNext && x.hasNext) {
             val point = x.next()
-            val assignment = y.next()
-            val previousAssignment = z.next()
-            if (previousAssignment.cluster != assignment.cluster) {
-              val previous = previousAssignment.cluster
-              if (previous != -1) {
-                initialize(previous)
-                centroids(previous).sub(point)
-              }
-              val current = assignment.cluster
-              if (current != -1) {
-                initialize(current)
-                centroids(current).add(point)
-              }
+            val current = y.next().cluster
+            val previous = z.next().cluster
+            if (previous != current) {
+              if (previous != -1) centroidAt(previous).sub(point)
+              if (current != -1) centroidAt(current).add(point)
             }
           }
           assert(y.hasNext == x.hasNext && z.hasNext == y.hasNext)

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -32,8 +32,6 @@ object ColumnTrackingKMeans {
   private[clusterer] val noCluster = -1
   private[clusterer] val unassigned = Assignment(Infinity, noCluster, -2)
 
-  private[clusterer] sealed trait CentroidChange
-
   private[clusterer] case class PointWithDistance(point: BregmanPoint,
     assignment: Assignment, dist: Double)
 

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -170,7 +170,7 @@ class ColumnTrackingKMeans(
       changes.foreach { case (index, delta) =>
         val c = currentCenters(index)
         val oldPosition = pointOps.toPoint(c.center)
-        val x = if (c.initialized) delta.add(oldPosition) else delta
+        val x = (if (c.initialized) delta.add(oldPosition) else delta).asImmutable
         currentCenters(index) = CenterWithHistory(pointOps.toCenter(x), index, round)
       }
       currentCenters

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -177,11 +177,9 @@ class ColumnTrackingKMeans(
           if (rand.nextDouble() > updateRate) unassigned
           else reassignment(point, current, round, stats, centers)
         }
-      }
-      newAssignments.setName(s"assignments round $round")
+      }.setName(s"assignments round $round").cache()
       newAssignments.zip(assignments).foreach { case (c, p) => updateStats(stats, c, p)}
       bcCenters.unpersist(blocking = false)
-      newAssignments.cache()
       assignments.unpersist(blocking = false)
       newAssignments
     }

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -422,10 +422,9 @@ class ColumnTrackingKMeans(
     points.unpersist(blocking = false)
 
     val (finalDistortion, finalCenters, finalAssignment) = results.minBy(_._1)
-    for ((_, _, assignment) <- results if assignment.id != finalAssignment.id) {
-      assignment.unpersist(blocking = false)
-    }
-    (finalDistortion, finalCenters, Some(finalAssignment.map(x => (x.cluster, x.distance))))
+    val best = (finalDistortion, finalCenters, Some(finalAssignment.map(x => (x.cluster, x.distance)).cache()))
+    for ((_, _, assignment) <- results) assignment.unpersist(blocking = true)
+    best
   }
 
   def nullAssignments(points: RDD[BregmanPoint]): RDD[Assignment] = points.map(x => unassigned).cache()

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -177,7 +177,7 @@ class ColumnTrackingKMeans(
       if (addOnly) {
         val results = getCompleteCentroids(points, currentAssignments, previousCenters.length)
         results.foreach { case (index, location) =>
-          val change = location.asImmutable
+          val change: WeightedVector = location.asImmutable
           logInfo(s"$index change is $change")
           currentCenters(index) = CenterWithHistory(pointOps.toCenter(change), index, round)
         }

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -81,7 +81,7 @@ class ColumnTrackingKMeans(
 
   import ColumnTrackingKMeans._
 
-  val addOnly = true
+  val addOnly = false
 
   /**
    * count number of points assigned to each cluster
@@ -263,11 +263,15 @@ class ColumnTrackingKMeans(
      * @return changes to cluster position
      */
 
-    /*
+
     def getExactCentroidChanges(
       points: RDD[BregmanPoint],
       currentAssignments: RDD[Assignment],
       previousAssignments: RDD[Assignment]): Map[Int, MutableWeightedVector] = {
+
+      require(points.getStorageLevel.useMemory)
+      require(currentAssignments.getStorageLevel.useMemory)
+      require(previousAssignments.getStorageLevel.useMemory)
 
       val additions = add(pointOps, points, changes(currentAssignments, previousAssignments))
       val subtractions = subtract(pointOps, points, changes(previousAssignments, currentAssignments))
@@ -283,50 +287,53 @@ class ColumnTrackingKMeans(
       }
     }
 
-    def getStochasticCentroidChanges(
-      points: RDD[BregmanPoint],
-      assignments: RDD[Assignment]): Map[Int, MutableWeightedVector] =
+    /*
 
-      points.zip(assignments).filter(_._2.isAssigned).map { case (o, p) =>
-        (p.cluster, o)
-      }.aggregateByKey(pointOps.getCentroid)(_.add(_), _.add(_)).collectAsMap()
+def getStochasticCentroidChanges(
+  points: RDD[BregmanPoint],
+  assignments: RDD[Assignment]): Map[Int, MutableWeightedVector] =
 
+  points.zip(assignments).filter(_._2.isAssigned).map { case (o, p) =>
+    (p.cluster, o)
+  }.aggregateByKey(pointOps.getCentroid)(_.add(_), _.add(_)).collectAsMap()
+
+
+def getExactCentroidChanges(
+  points: RDD[BregmanPoint],
+  currentAssignments: RDD[Assignment],
+  previousAssignments: RDD[Assignment]): Array[(Int, MutableWeightedVector)] = {
+
+  require(points.getStorageLevel.useMemory)
+  require(currentAssignments.getStorageLevel.useMemory)
+  require(previousAssignments.getStorageLevel.useMemory)
+
+  val changes = currentAssignments.zip(previousAssignments).map { case (curr, prev) =>
+    (curr.cluster, prev.cluster)
+  }.setName("changes").cache()
+
+  val results = points.zip(changes).mapPartitions { pts =>
+    val buffer = new ArrayBuffer[(Int, CentroidChange)]
+    for ((point, (add, sub)) <- pts) {
+      if (add != sub) {
+        if (add >= 0) buffer.append((add, Add(point)))
+        if (sub >= 0) buffer.append((sub, Sub(point)))
+      }
+    }
+    logInfo(s"buffer size ${buffer.size}")
+    buffer.iterator
+  }.aggregateByKey(pointOps.getCentroid)(
+      (x, y) => y match {
+        case Add(p) => x.add(p)
+        case Sub(p) => x.sub(p)
+      },
+      (x, y) => x.add(y)
+    ).collect()
+
+  changes.unpersist()
+  results
+}
 
 */
-    def getExactCentroidChanges(
-      points: RDD[BregmanPoint],
-      currentAssignments: RDD[Assignment],
-      previousAssignments: RDD[Assignment]): Array[(Int, MutableWeightedVector)] = {
-
-      require(points.getStorageLevel.useMemory)
-      require(currentAssignments.getStorageLevel.useMemory)
-      require(previousAssignments.getStorageLevel.useMemory)
-
-      val changes = currentAssignments.zip(previousAssignments).map { case (curr, prev) =>
-        (curr.cluster, prev.cluster)
-      }.setName("changes").cache()
-
-      val results = points.zip(changes).mapPartitions { pts =>
-        val buffer = new ArrayBuffer[(Int, CentroidChange)]
-        for ((point, (add, sub)) <- pts) {
-          if (add != sub) {
-            if (add >= 0) buffer.append((add, Add(point)))
-            if (sub >= 0) buffer.append((sub, Sub(point)))
-          }
-        }
-        logInfo(s"buffer size ${buffer.size}")
-        buffer.iterator
-      }.aggregateByKey(pointOps.getCentroid)(
-          (x, y) => y match {
-            case Add(p) => x.add(p)
-            case Sub(p) => x.sub(p)
-          },
-          (x, y) => x.add(y)
-        ).collect()
-
-      changes.unpersist()
-      results
-    }
 
     def getStochasticCentroidChanges(
       points: RDD[BregmanPoint],

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -223,17 +223,22 @@ class ColumnTrackingKMeans(
       stats.unassignedPoints.setValue(0)
       stats.improvement.setValue(0)
       stats.newlyAssignedPoints.setValue(0)
-      currentAssignments.zip(previousAssignments).foreach { case (current, previous) =>
-        if (current.isAssigned) {
-          if (previous.isAssigned) {
-            stats.improvement.add(previous.distance - current.distance)
-            if (current.cluster != previous.cluster) stats.reassignedPoints.add(1)
+      currentAssignments.zipPartitions(previousAssignments) { case (c, p) =>
+        while (c.hasNext && p.hasNext) {
+          val current = c.next()
+          val previous = p.next()
+          if (current.isAssigned) {
+            if (previous.isAssigned) {
+              stats.improvement.add(previous.distance - current.distance)
+              if (current.cluster != previous.cluster) stats.reassignedPoints.add(1)
+            } else {
+              stats.newlyAssignedPoints.add(1)
+            }
           } else {
-            stats.newlyAssignedPoints.add(1)
+            stats.unassignedPoints.add(1)
           }
-        } else {
-          stats.unassignedPoints.add(1)
         }
+        null
       }
 
       val clusterCounts = countByCluster(currentAssignments)

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -192,6 +192,7 @@ class ColumnTrackingKMeans(
       currentAssignments: RDD[Assignment],
       previousAssignments: RDD[Assignment]): Boolean = {
 
+      logInfo("start of stats collection")
       stats.currentRound.setValue(round)
 
       stats.movement.setValue(0.0)
@@ -227,6 +228,7 @@ class ColumnTrackingKMeans(
       stats.emptyClusters.setValue(currentCenters.size - clusterCounts.size)
       stats.report()
 
+      logInfo("end of stats collection")
       terminationCondition(stats)
     }
 

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -142,7 +142,7 @@ class ColumnTrackingKMeans(
             else reassignment(point, current, round, centers)
           }
       }
-      bcCenters.unpersist(blocking = false)
+      bcCenters.unpersist()
       currentAssignments.setName(s"assignments round $round").cache()
     }
 
@@ -398,7 +398,7 @@ class ColumnTrackingKMeans(
           }
         }
       }.reduceByKeyLocally { (x, y) => if (x.dist < y.dist) x else y}
-      bcCenters.unpersist(blocking = false)
+      bcCenters.unpersist()
       result
     }
 
@@ -424,7 +424,7 @@ class ColumnTrackingKMeans(
       previousAssignments: RDD[Assignment]): RDD[Assignment] = {
 
       val newCenters = updatedCenters(round, assignments, previousAssignments, centers)
-      previousAssignments.unpersist(blocking = false)
+      previousAssignments.unpersist()
       val newAssignments = updatedAssignments(round, assignments, newCenters)
       val terminate = shouldTerminate(round, newCenters, centers, newAssignments, assignments)
       if (terminate) newAssignments else lloyds(round + 1, newCenters, newAssignments, assignments)
@@ -435,10 +435,9 @@ class ColumnTrackingKMeans(
     logInfo(s"runs = ${centerArrays.size}")
 
     val candidates = clusterings(points, centerArrays)
-    points.unpersist(blocking = false)
     val (d, centers, assignments) = candidates.minBy(_._1)
     val best = (d, centers, Some(assignments.map(x => (x.cluster, x.distance)).cache()))
-    for ((_, _, a) <- candidates) a.unpersist(blocking = false)
+    for ((_, _, a) <- candidates) a.unpersist()
     best
   }
 

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -59,9 +59,9 @@ object ColumnTrackingKMeans {
    * @param round the round in which his cluster was last moved
    */
   private[clusterer] case class CenterWithHistory(center: BregmanCenter, index: Int, round: Int = -1) {
-    def movedSince(r: Int): Boolean = round >= r
+    @inline def movedSince(r: Int): Boolean = round >= r
 
-    def initialized: Boolean = round >= 0
+    @inline def initialized: Boolean = round >= 0
   }
 
 }

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -173,7 +173,6 @@ class ColumnTrackingKMeans(
         results.foreach { case (index, location) =>
           val change: WeightedVector = location.asImmutable
           val newCenter = CenterWithHistory(pointOps.toCenter(change), index, round)
-          logInfo(s"new center at $index  is $newCenter")
           currentCenters(index) = newCenter
         }
       } else {

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -179,7 +179,7 @@ class ColumnTrackingKMeans(
         results.foreach { case (index, location) =>
           val change = location.asImmutable
           logInfo(s"$index change is $change")
-          currentCenters(index) = CenterWithHistory(pointOps.toCenter(location.asImmutable), index, round)
+          currentCenters(index) = CenterWithHistory(pointOps.toCenter(change), index, round)
         }
       } else {
         val changes = getCentroidChanges(points, currentAssignments, previousAssignments, previousCenters.length)

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -312,6 +312,7 @@ class ColumnTrackingKMeans(
         val indexBuffer = new mutable.ArrayBuilder.ofInt
         indexBuffer.sizeHint(numCenters)
 
+        var i = 0
         while (y.hasNext && x.hasNext) {
           val point = x.next()
           val assignment = y.next()
@@ -323,8 +324,10 @@ class ColumnTrackingKMeans(
             }
             centroids(index).add(point)
           }
+          i = i + 1
         }
         assert(y.hasNext == x.hasNext)
+        logInfo(s"partition had $i points")
 
         val changedClusters = indexBuffer.result()
         logInfo(s"number of clusters changed = ${changedClusters.length}")

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -250,7 +250,7 @@ class ColumnTrackingKMeans(
 
       val changes = currentAssignments.zip(previousAssignments).map { case (curr, prev) =>
         (curr.cluster, prev.cluster)
-      }.cache()
+      }.setName("changes").cache()
 
       val results = points.zip(changes).mapPartitions { pts =>
         val buffer = new ArrayBuffer[(Int, CentroidChange)]

--- a/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/ColumnTrackingKMeans.scala
@@ -198,10 +198,10 @@ class ColumnTrackingKMeans(
       stats.movement.setValue(0.0)
       stats.relocatedCenters.setValue(0)
       currentCenters.zip(previousCenters).foreach { case (current, previous) =>
-        if (current.round != previous.round)
+        if (current.round == round) {
           stats.movement.add(pointOps.distance(pointOps.toPoint(previous.center), current.center))
-        if (current.round == round)
           stats.relocatedCenters.add(1)
+        }
       }
 
       stats.reassignedPoints.setValue(0)

--- a/src/main/scala/com/massivedatascience/clusterer/HasLog.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/HasLog.scala
@@ -27,7 +27,7 @@ object GeneralLog extends HasLog {
 }
 
 object DiscreteLog extends HasLog{
-  private val logTable = new Array[Double](4096 * 1000)
+  private val logTable = new Array[Double](1000)
 
   override def log(d: Double): Double = {
     if (d == 0.0 || d == 1.0) {

--- a/src/main/scala/com/massivedatascience/clusterer/KMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeans.scala
@@ -226,7 +226,7 @@ object KMeans extends Logging {
     implicit clusterer: MultiKMeansClusterer): KMeansInitializer = {
     initializerName match {
       case RANDOM => new KMeansRandom(k, runs, 0)
-      case K_MEANS_PARALLEL => new KMeansParallel(k, runs, initializationSteps, 0, clusterer)
+      case K_MEANS_PARALLEL => new KMeansParallel(k, runs, initializationSteps, 0, new TrackingKMeans(terminationCondition = { s: BasicStats => s.getRound > 3}))
       case _ => throw new RuntimeException(s"unknown initializer $initializerName")
     }
   }

--- a/src/main/scala/com/massivedatascience/clusterer/KMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeans.scala
@@ -226,7 +226,7 @@ object KMeans extends Logging {
     implicit clusterer: MultiKMeansClusterer): KMeansInitializer = {
     initializerName match {
       case RANDOM => new KMeansRandom(k, runs, 0)
-      case K_MEANS_PARALLEL => new KMeansParallel(k, runs, initializationSteps, 0, new TrackingKMeans(terminationCondition = { s: BasicStats => s.getRound > 3}))
+      case K_MEANS_PARALLEL => new KMeansParallel(k, runs, initializationSteps, 0, new ColumnTrackingKMeans(terminationCondition = { s: BasicStats => s.getRound > 3}))
       case _ => throw new RuntimeException(s"unknown initializer $initializerName")
     }
   }

--- a/src/main/scala/com/massivedatascience/clusterer/KMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeans.scala
@@ -310,9 +310,8 @@ object KMeans extends Logging {
     depth: Int = 0,
     embedding: Embedding = HaarEmbedding): List[RDD[Vector]] = {
     val subs = (0 until depth).foldLeft(List(dataSet)) {
-      case (data, e) => {
+      case (data, e) =>
         data.head.map(embedding.embed).setName(s"embedded data at depth $depth with $embedding") :: data
-      }
     }
     subs
   }

--- a/src/main/scala/com/massivedatascience/clusterer/KMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeans.scala
@@ -231,12 +231,13 @@ object KMeans extends Logging {
     implicit clusterer: MultiKMeansClusterer): (KMeansModel, KMeansResults) = {
 
     val (bregmanPoints, initialCenters) = initializer.init(distanceFunc, raw)
-    bregmanPoints.setName("Bregman points")
+    bregmanPoints.setName("Bregman points").cache()
     val (cost, finalCenters, assignmentOpt) =
       clusterer.cluster(distanceFunc, bregmanPoints, initialCenters)
     val assignments = assignmentOpt.getOrElse {
       bregmanPoints.map(p => distanceFunc.findClosest(finalCenters, p)).setName("assignments")
     }
+    bregmanPoints.unpersist()
     (new KMeansModel(distanceFunc, finalCenters), new KMeansResults(cost, assignments))
   }
 

--- a/src/main/scala/com/massivedatascience/clusterer/KMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeans.scala
@@ -226,7 +226,7 @@ object KMeans extends Logging {
     implicit clusterer: MultiKMeansClusterer): KMeansInitializer = {
     initializerName match {
       case RANDOM => new KMeansRandom(k, runs, 0)
-      case K_MEANS_PARALLEL => new KMeansParallel(k, runs, initializationSteps, 0, new ColumnTrackingKMeans(terminationCondition = { s: BasicStats => s.getRound > 3}))
+      case K_MEANS_PARALLEL => new KMeansParallel(k, runs, initializationSteps, 0, clusterer)
       case _ => throw new RuntimeException(s"unknown initializer $initializerName")
     }
   }

--- a/src/main/scala/com/massivedatascience/clusterer/KMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeans.scala
@@ -175,7 +175,6 @@ object KMeans extends Logging {
     val samples = subsample(data, depth, embedding)
     val ops = Array.fill(depth + 1)(distanceFunc)
     val results = iterativelyTrain(ops, samples, initializer)
-    samples.reverse.tail.map(_.unpersist())
     results
   }
 
@@ -261,7 +260,6 @@ object KMeans extends Logging {
 
     val samples = subsample(raw, depth, embedding)
     val results = iterativelyTrain(Array.fill(depth + 1)(pointOps), samples, initializer)
-    samples.reverse.tail.map(_.unpersist())
     results
   }
 
@@ -276,7 +274,6 @@ object KMeans extends Logging {
 
     val samples = resample(raw, embeddings)
     val results = iterativelyTrain(ops, samples, initializer)
-    samples.map(_.unpersist())
     results
   }
 
@@ -314,7 +311,7 @@ object KMeans extends Logging {
     embedding: Embedding = HaarEmbedding): List[RDD[Vector]] = {
     val subs = (0 until depth).foldLeft(List(dataSet)) {
       case (data, e) => {
-        data.head.map(embedding.embed).cache().setName(s"embedded data at depth $depth with $embedding") :: data
+        data.head.map(embedding.embed).setName(s"embedded data at depth $depth with $embedding") :: data
       }
     }
     subs
@@ -331,7 +328,7 @@ object KMeans extends Logging {
   private def resample(
     dataSet: RDD[Vector],
     embeddings: Seq[Embedding] = Seq(IdentityEmbedding)): Seq[RDD[Vector]] = {
-    embeddings.map(x => dataSet.map(x.embed).cache().setName(s"embedded data with $x"))
+    embeddings.map(x => dataSet.map(x.embed).setName(s"embedded data with $x"))
   }
 
 }

--- a/src/main/scala/com/massivedatascience/clusterer/KMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeans.scala
@@ -235,6 +235,7 @@ object KMeans extends Logging {
 
     val (bregmanPoints, initialCenters) = initializer.init(distanceFunc, raw)
     bregmanPoints.setName("Bregman points")
+    assert(bregmanPoints.getStorageLevel.useMemory)
     val (cost, finalCenters, assignmentOpt) =
       clusterer.cluster(distanceFunc, bregmanPoints, initialCenters)
     val assignments = assignmentOpt.getOrElse {

--- a/src/main/scala/com/massivedatascience/clusterer/KMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeans.scala
@@ -20,6 +20,7 @@ package com.massivedatascience.clusterer
 import org.apache.spark.Logging
 import org.apache.spark.mllib.linalg.Vector
 import org.apache.spark.rdd.RDD
+import org.apache.spark.storage.StorageLevel
 
 
 object KMeans extends Logging {
@@ -231,7 +232,7 @@ object KMeans extends Logging {
     implicit clusterer: MultiKMeansClusterer): (KMeansModel, KMeansResults) = {
 
     val (bregmanPoints, initialCenters) = initializer.init(distanceFunc, raw)
-    bregmanPoints.setName("Bregman points").cache()
+    bregmanPoints.setName("Bregman points").persist(StorageLevel.MEMORY_ONLY_SER)
     val (cost, finalCenters, assignmentOpt) =
       clusterer.cluster(distanceFunc, bregmanPoints, initialCenters)
     val assignments = assignmentOpt.getOrElse {

--- a/src/main/scala/com/massivedatascience/clusterer/KMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeans.scala
@@ -232,7 +232,7 @@ object KMeans extends Logging {
     implicit clusterer: MultiKMeansClusterer): (KMeansModel, KMeansResults) = {
 
     val (bregmanPoints, initialCenters) = initializer.init(distanceFunc, raw)
-    bregmanPoints.setName("Bregman points").persist(StorageLevel.MEMORY_ONLY_SER)
+    bregmanPoints.setName("Bregman points")
     val (cost, finalCenters, assignmentOpt) =
       clusterer.cluster(distanceFunc, bregmanPoints, initialCenters)
     val assignments = assignmentOpt.getOrElse {

--- a/src/main/scala/com/massivedatascience/clusterer/KMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeans.scala
@@ -314,7 +314,7 @@ object KMeans extends Logging {
     embedding: Embedding = HaarEmbedding): List[RDD[Vector]] = {
     val subs = (0 until depth).foldLeft(List(dataSet)) {
       case (data, e) => {
-        data.head.map(embedding.embed).cache() :: data
+        data.head.map(embedding.embed).cache().setName(s"embedded data at depth $depth with $embedding") :: data
       }
     }
     subs
@@ -331,7 +331,7 @@ object KMeans extends Logging {
   private def resample(
     dataSet: RDD[Vector],
     embeddings: Seq[Embedding] = Seq(IdentityEmbedding)): Seq[RDD[Vector]] = {
-    embeddings.map(x => dataSet.map(x.embed).cache())
+    embeddings.map(x => dataSet.map(x.embed).cache().setName(s"embedded data with $x"))
   }
 
 }

--- a/src/main/scala/com/massivedatascience/clusterer/KMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeans.scala
@@ -33,6 +33,7 @@ object KMeans extends Logging {
   val DISCRETE_KL = "DISCRETE_DENSE_KL_DIVERGENCE"
   val SPARSE_SMOOTHED_KL = "SPARSE_SMOOTHED_KL_DIVERGENCE"
   val DISCRETE_SMOOTHED_KL = "DISCRETE_DENSE_SMOOTHED_KL_DIVERGENCE"
+  val SIMPLEX_SMOOTHED_KL = "SIMPLEX_SMOOTHED_KL"
   val GENERALIZED_SYMMETRIZED_KL = "GENERALIZED_SYMMETRIZED_KL"
   val EUCLIDEAN = "DENSE_EUCLIDEAN"
   val SPARSE_EUCLIDEAN = "SPARSE_EUCLIDEAN"
@@ -181,6 +182,7 @@ object KMeans extends Logging {
       case EUCLIDEAN => DenseSquaredEuclideanPointOps
       case RELATIVE_ENTROPY => DenseKLPointOps
       case DISCRETE_KL => DiscreteDenseKLPointOps
+      case SIMPLEX_SMOOTHED_KL => DiscreteDenseSimplexSmoothedKLPointOps
       case DISCRETE_SMOOTHED_KL => DiscreteDenseSmoothedKLPointOps
       case SPARSE_SMOOTHED_KL => SparseRealKLPointOps
       case SPARSE_EUCLIDEAN => SparseSquaredEuclideanPointOps

--- a/src/main/scala/com/massivedatascience/clusterer/KMeansModel.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeansModel.scala
@@ -39,15 +39,15 @@ class KMeansModel(pointOps: BregmanPointOps, centers: Array[BregmanCenter])
 
   /** Returns the cluster index that a given point belongs to. */
   def predict(point: Vector): Int =
-    pointOps.findClosestCluster(centers, pointOps.inhomogeneousToPoint(point, 1.0))
+    pointOps.findClosestCluster(centers, pointOps.vectorToPoint(point))
 
 
   def predictClusterAndDistance(point: Vector): (Int, Double) =
-    pointOps.findClosest(centers, pointOps.inhomogeneousToPoint(point, 1.0))
+    pointOps.findClosest(centers, pointOps.vectorToPoint(point))
 
   /** Maps given points to their cluster indices. */
   def predict(points: RDD[Vector]): RDD[Int] =
-    points.map(p => pointOps.findClosestCluster(centers, pointOps.inhomogeneousToPoint(p, 1.0)))
+    points.map(p => pointOps.findClosestCluster(centers, pointOps.vectorToPoint(p)))
 
 
   /** Maps given points to their cluster indices. */
@@ -59,6 +59,6 @@ class KMeansModel(pointOps: BregmanPointOps, centers: Array[BregmanCenter])
    * model on the given data.
    */
   def computeCost(data: RDD[Vector]): Double =
-    data.map(p => pointOps.findClosest(centers, pointOps.inhomogeneousToPoint(p, 1.0))._2).sum()
+    data.map(p => pointOps.findClosest(centers, pointOps.vectorToPoint(p))._2).sum()
 
 }

--- a/src/main/scala/com/massivedatascience/clusterer/KMeansParallel.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeansParallel.scala
@@ -57,7 +57,7 @@ class KMeansParallel(
       val weightMap = data.flatMap { point =>
         val centers = bcCenters.value
         Array.tabulate(runs)(r => ((r, pointOps.findClosestCluster(centers(r), point)), point.weight))
-      }.reduceByKeyLocally(_ + _)
+      }.reduceByKey(_ + _).collectAsMap()
 
       val centers = bcCenters.value
       val kmeansPlusPlus = new KMeansPlusPlus(pointOps, clusterer)

--- a/src/main/scala/com/massivedatascience/clusterer/KMeansParallel.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeansParallel.scala
@@ -39,12 +39,6 @@ class KMeansParallel(
   clusterer: MultiKMeansClusterer)
   extends KMeansInitializer with Logging {
 
-  class NotSerializable {
-
-  }
-
-  val x = new NotSerializable
-
   def init(pointOps: BregmanPointOps, d: RDD[Vector]): (RDD[BregmanPoint], Array[Array[BregmanCenter]]) = {
 
     /**
@@ -61,7 +55,6 @@ class KMeansParallel(
       bcCenters: Broadcast[Array[Array[BregmanCenter]]], seed: Int): Array[Array[BregmanCenter]] = {
 
       val runs = r
-
 
       // for each (run, cluster) compute the sum of the weights of the points in the cluster
       val weightMap = data.flatMap { point =>
@@ -105,13 +98,11 @@ class KMeansParallel(
 
     val runs = r
 
-
     // Initialize empty centers and point costs.
     val centers = Array.tabulate(runs)(r => ArrayBuffer.empty[BregmanCenter])
     var costs = data.map(_ => Vectors.dense(Array.fill(runs)(Double.PositiveInfinity)))
     costs.persist(StorageLevel.OFF_HEAP)
     costs.setName("pre-costs")
-
 
     // Initialize each run's first center to a random point.
     val seed = new XORShiftRandom(seedx).nextInt()
@@ -179,8 +170,8 @@ class KMeansParallel(
       }.collect()
       logInfo(s"merging centers")
       mergeNewCenters()
-      chosen.foreach { case (r, center) =>
-        newCenters(r) += center
+      chosen.foreach { case (index, center) =>
+        newCenters(index) += center
       }
       step += 1
     }

--- a/src/main/scala/com/massivedatascience/clusterer/KMeansParallel.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeansParallel.scala
@@ -88,7 +88,7 @@ class KMeansParallel(
    * @return
    */
 
-    val data = d.map{p=>pointOps.inhomogeneousToPoint(p,1.0)}
+    val data = d.map(pointOps.vectorToPoint)
     data.setName("initial points")
     data.persist()
 

--- a/src/main/scala/com/massivedatascience/clusterer/KMeansParallel.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeansParallel.scala
@@ -90,7 +90,7 @@ class KMeansParallel(
 
     val data = d.map{p=>pointOps.inhomogeneousToPoint(p,1.0)}
     data.setName("initial points")
-    data.persist(StorageLevel.MEMORY_ONLY_SER)
+    data.persist()
 
     // Initialize empty centers and point costs.
     val centers = Array.tabulate(runs)(r => ArrayBuffer.empty[BregmanCenter])

--- a/src/main/scala/com/massivedatascience/clusterer/KMeansParallel.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeansParallel.scala
@@ -90,7 +90,7 @@ class KMeansParallel(
 
     val data = d.map{p=>pointOps.inhomogeneousToPoint(p,1.0)}
     data.setName("initial points")
-    data.cache()
+    data.persist(StorageLevel.MEMORY_ONLY_SER)
 
     // Initialize empty centers and point costs.
     val centers = Array.tabulate(runs)(r => ArrayBuffer.empty[BregmanCenter])

--- a/src/main/scala/com/massivedatascience/clusterer/KMeansParallel.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeansParallel.scala
@@ -70,9 +70,9 @@ class KMeansParallel(
         val kx = if (k > myCenters.length) myCenters.length else k
         val initial = kmeansPlusPlus.getCenters(sc, seed, myCenters, weights, kx, 1)
         val parallelCenters = sc.parallelize(myCenters.map(pointOps.toPoint))
-        val clustering = clusterer.cluster(pointOps, parallelCenters, Array(initial))
-        clustering._3.map(_.unpersist(blocking = false))
-        clustering._2
+        val (_, clusters, assignments) = clusterer.cluster(pointOps, parallelCenters, Array(initial))
+        assignments.map(_.unpersist(blocking = false))
+        clusters
       }
     }
 

--- a/src/main/scala/com/massivedatascience/clusterer/KMeansParallel.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeansParallel.scala
@@ -129,7 +129,7 @@ class KMeansParallel(
           })
       }
       costs.cache()
-      costs.setName(s"costs at step $step")
+      costs.setName(s"costs at step $step,")
       val sumCosts = costs
         .aggregate(Vectors.zeros(runs))(
           seqOp = (s, v) => {

--- a/src/main/scala/com/massivedatascience/clusterer/KMeansParallel.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeansParallel.scala
@@ -101,7 +101,7 @@ class KMeansParallel(
 
     val data = d.map(pointOps.vectorToPoint)
     data.setName("initial points")
-    data.persist()
+    data.persist(StorageLevel.OFF_HEAP)
 
     val runs = r
 
@@ -109,8 +109,9 @@ class KMeansParallel(
     // Initialize empty centers and point costs.
     val centers = Array.tabulate(runs)(r => ArrayBuffer.empty[BregmanCenter])
     var costs = data.map(_ => Vectors.dense(Array.fill(runs)(Double.PositiveInfinity)))
-    costs.cache()
+    costs.persist(StorageLevel.OFF_HEAP)
     costs.setName("pre-costs")
+
 
     // Initialize each run's first center to a random point.
     val seed = new XORShiftRandom(seedx).nextInt()

--- a/src/main/scala/com/massivedatascience/clusterer/KMeansParallel.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeansParallel.scala
@@ -95,6 +95,7 @@ class KMeansParallel(
     val data = d.map(pointOps.vectorToPoint)
     data.setName("initial points")
     data.persist(StorageLevel.OFF_HEAP)
+    data.count()
 
     val runs = r
 
@@ -103,6 +104,7 @@ class KMeansParallel(
     var costs = data.map(_ => Vectors.dense(Array.fill(runs)(Double.PositiveInfinity)))
     costs.persist(StorageLevel.OFF_HEAP)
     costs.setName("pre-costs")
+    costs.count()
 
     // Initialize each run's first center to a random point.
     val seed = new XORShiftRandom(seedx).nextInt()

--- a/src/main/scala/com/massivedatascience/clusterer/KMeansParallel.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeansParallel.scala
@@ -94,7 +94,7 @@ class KMeansParallel(
 
     val data = d.map(pointOps.vectorToPoint)
     data.setName("initial points")
-    data.persist(StorageLevel.OFF_HEAP)
+    data.persist()
     data.count()
 
     val runs = r
@@ -102,7 +102,7 @@ class KMeansParallel(
     // Initialize empty centers and point costs.
     val centers = Array.tabulate(runs)(r => ArrayBuffer.empty[BregmanCenter])
     var costs = data.map(_ => Vectors.dense(Array.fill(runs)(Double.PositiveInfinity)))
-    costs.persist(StorageLevel.OFF_HEAP)
+    costs.persist()
     costs.setName("pre-costs")
     costs.count()
 

--- a/src/main/scala/com/massivedatascience/clusterer/KMeansPlusPlus.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeansPlusPlus.scala
@@ -51,16 +51,6 @@ class KMeansPlusPlus(ops: BregmanPointOps, clusterer: MultiKMeansClusterer) exte
     clustering._2
   }
 
-  def showMemory() {
-    val mb: Int = 1024 * 1024
-    val runtime: Runtime = Runtime.getRuntime
-    logInfo("##### Heap utilization statistics [MB] #####")
-    logInfo("Used Memory:" + (runtime.totalMemory - runtime.freeMemory) / mb)
-    logInfo("Free Memory:" + runtime.freeMemory / mb)
-    logInfo("Total Memory:" + runtime.totalMemory / mb)
-    logInfo("Max Memory:" + runtime.maxMemory / mb)
-  }
-
   /**
    * Select centers in rounds.  On each round, select 'perRound' centers, with probability of
    * selection equal to the product of the given weights and distance to the closest cluster center
@@ -94,15 +84,12 @@ class KMeansPlusPlus(ops: BregmanPointOps, clusterer: MultiKMeansClusterer) exte
     val rand = new XORShiftRandom(seed)
     val newCenter = pickWeighted(rand, weights).map(candidateCenters(_))
     centers += newCenter.get
-    logInfo(s"starting kMeansPlusPlus initialization on ${candidateCenters.length} points")
-
-    showMemory()
+    logInfo(s"starting kMeansPlusPlus initializatieon on ${candidateCenters.length} points")
 
     var distances = Array.fill(candidateCenters.length)(Double.MaxValue)
     distances = updateDistances(points, distances, IndexedSeq(newCenter.get))
     var more = true
     while (centers.length < k && more) {
-      showMemory()
       val selected = (0 until perRound).par.flatMap { _ =>
         pickWeighted(rand, points.zip(distances).map{ case (p,d) => p.weight * d})
       }

--- a/src/main/scala/com/massivedatascience/clusterer/KMeansPlusPlus.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeansPlusPlus.scala
@@ -123,7 +123,7 @@ class KMeansPlusPlus(ops: BregmanPointOps, clusterer: MultiKMeansClusterer) exte
     points.zip(distances).par.map { case (p, d) =>
       val dist = ops.pointCost(centers, p)
       if(dist < d) dist else d
-    }
+    }.toArray
   }
 
   /**

--- a/src/main/scala/com/massivedatascience/clusterer/KMeansPlusPlus.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeansPlusPlus.scala
@@ -90,7 +90,7 @@ class KMeansPlusPlus(ops: BregmanPointOps, clusterer: MultiKMeansClusterer) exte
     distances = updateDistances(points, distances, IndexedSeq(newCenter.get))
     var more = true
     while (centers.length < k && more) {
-      val selected = (0 until perRound).flatMap {_ =>
+      val selected = (0 until perRound).par.flatMap { _ =>
         pickWeighted(rand, points.zip(distances).map{ case (p,d) => p.weight * d})
       }
       val newCenters = selected.toArray.map(candidateCenters(_))
@@ -119,8 +119,8 @@ class KMeansPlusPlus(ops: BregmanPointOps, clusterer: MultiKMeansClusterer) exte
     points: Array[BregmanPoint],
     distances: Array[Double],
     centers: IndexedSeq[BregmanCenter]): Array[Double] = {
-    
-    points.zip(distances).map { case (p, d) =>
+
+    points.zip(distances).par.map { case (p, d) =>
       val dist = ops.pointCost(centers, p)
       if(dist < d) dist else d
     }

--- a/src/main/scala/com/massivedatascience/clusterer/KMeansPlusPlus.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeansPlusPlus.scala
@@ -51,6 +51,16 @@ class KMeansPlusPlus(ops: BregmanPointOps, clusterer: MultiKMeansClusterer) exte
     clustering._2
   }
 
+  def showMemory() {
+    val mb: Int = 1024 * 1024
+    val runtime: Runtime = Runtime.getRuntime
+    logInfo("##### Heap utilization statistics [MB] #####")
+    logInfo("Used Memory:" + (runtime.totalMemory - runtime.freeMemory) / mb)
+    logInfo("Free Memory:" + runtime.freeMemory / mb)
+    logInfo("Total Memory:" + runtime.totalMemory / mb)
+    logInfo("Max Memory:" + runtime.maxMemory / mb)
+  }
+
   /**
    * Select centers in rounds.  On each round, select 'perRound' centers, with probability of
    * selection equal to the product of the given weights and distance to the closest cluster center
@@ -86,10 +96,13 @@ class KMeansPlusPlus(ops: BregmanPointOps, clusterer: MultiKMeansClusterer) exte
     centers += newCenter.get
     logInfo(s"starting kMeansPlusPlus initialization on ${candidateCenters.length} points")
 
+    showMemory()
+
     var distances = Array.fill(candidateCenters.length)(Double.MaxValue)
     distances = updateDistances(points, distances, IndexedSeq(newCenter.get))
     var more = true
     while (centers.length < k && more) {
+      showMemory()
       val selected = (0 until perRound).par.flatMap { _ =>
         pickWeighted(rand, points.zip(distances).map{ case (p,d) => p.weight * d})
       }

--- a/src/main/scala/com/massivedatascience/clusterer/KMeansRandom.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeansRandom.scala
@@ -34,6 +34,7 @@ class KMeansRandom(k: Int, runs: Int, seed: Int) extends KMeansInitializer {
     }
 
     val data = d.map(ops.vectorToPoint)
+    data.persist()
     val filtered = data.filter(_.weight > ops.weightThreshold).setName("random initial")
     filtered.persist()
 

--- a/src/main/scala/com/massivedatascience/clusterer/KMeansRandom.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeansRandom.scala
@@ -33,7 +33,7 @@ class KMeansRandom(k: Int, runs: Int, seed: Int) extends KMeansInitializer {
       data.takeSample(withReplacement = false, count, new XORShiftRandom().nextInt()).map(toCenter)
     }
 
-    val data = d.map { p => ops.inhomogeneousToPoint(p, 1.0)}
+    val data = d.map(ops.vectorToPoint)
     val filtered = data.filter(_.weight > ops.weightThreshold).setName("random initial")
     filtered.persist()
 

--- a/src/main/scala/com/massivedatascience/clusterer/KMeansRandom.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeansRandom.scala
@@ -34,7 +34,9 @@ class KMeansRandom(k: Int, runs: Int, seed: Int) extends KMeansInitializer {
     }
 
     val data = d.map { p => ops.inhomogeneousToPoint(p, 1.0)}
-    val filtered = data.filter(_.weight > ops.weightThreshold).cache()
+    val filtered = data.filter(_.weight > ops.weightThreshold).setName("random initial")
+    filtered.persist(StorageLevel.MEMORY_ONLY_SER)
+
     val count = filtered.count()
     val centers = if (runs * k <= count) {
       val centers = select(filtered, runs * k)

--- a/src/main/scala/com/massivedatascience/clusterer/KMeansRandom.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeansRandom.scala
@@ -28,15 +28,13 @@ class KMeansRandom(k: Int, runs: Int, seed: Int) extends KMeansInitializer {
 
   def init(ops: BregmanPointOps, d: RDD[Vector]): (RDD[BregmanPoint], Array[Array[BregmanCenter]]) = {
 
-    def select(data: RDD[BregmanPoint], count: Int) =
-    {
+    def select(data: RDD[BregmanPoint], count: Int) = {
       val toCenter = ops.toCenter _
       data.takeSample(withReplacement = false, count, new XORShiftRandom().nextInt()).map(toCenter)
     }
 
     val data = d.map { p => ops.inhomogeneousToPoint(p, 1.0)}
-    data.persist(StorageLevel.MEMORY_AND_DISK)
-    val filtered = data.filter(_.weight > ops.weightThreshold)
+    val filtered = data.filter(_.weight > ops.weightThreshold).cache()
     val count = filtered.count()
     val centers = if (runs * k <= count) {
       val centers = select(filtered, runs * k)
@@ -47,6 +45,7 @@ class KMeansRandom(k: Int, runs: Int, seed: Int) extends KMeansInitializer {
       val all = filtered.collect().map(ops.toCenter)
       Array.fill(runs)(all)
     }
+    filtered.unpersist()
     (data, centers)
   }
 }

--- a/src/main/scala/com/massivedatascience/clusterer/KMeansRandom.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/KMeansRandom.scala
@@ -35,7 +35,7 @@ class KMeansRandom(k: Int, runs: Int, seed: Int) extends KMeansInitializer {
 
     val data = d.map { p => ops.inhomogeneousToPoint(p, 1.0)}
     val filtered = data.filter(_.weight > ops.weightThreshold).setName("random initial")
-    filtered.persist(StorageLevel.MEMORY_ONLY_SER)
+    filtered.persist()
 
     val count = filtered.count()
     val centers = if (runs * k <= count) {

--- a/src/main/scala/com/massivedatascience/clusterer/SampleInitializer.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/SampleInitializer.scala
@@ -20,6 +20,7 @@ package com.massivedatascience.clusterer
 import org.apache.spark.SparkContext._
 import org.apache.spark.mllib.linalg.Vector
 import org.apache.spark.rdd.RDD
+import org.apache.spark.storage.StorageLevel
 
 class SampleInitializer(val assignments: RDD[Int]) extends KMeansInitializer {
   def init(
@@ -28,7 +29,7 @@ class SampleInitializer(val assignments: RDD[Int]) extends KMeansInitializer {
 
     val data = d.map {pt => pointOps.inhomogeneousToPoint(pt, 1.0)}
     data.setName("input to sample initializer")
-    data.cache()
+    data.persist(StorageLevel.MEMORY_ONLY_SER)
 
     val centroids = assignments.zip(data).aggregateByKey(pointOps.getCentroid)(
       (centroid, pt) => centroid.add(pt),

--- a/src/main/scala/com/massivedatascience/clusterer/SampleInitializer.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/SampleInitializer.scala
@@ -26,7 +26,7 @@ class SampleInitializer(val assignments: RDD[Int]) extends KMeansInitializer {
     pointOps: BregmanPointOps,
     d: RDD[Vector]): (RDD[BregmanPoint], Array[Array[BregmanCenter]]) = {
 
-    val data = d.map {pt => pointOps.inhomogeneousToPoint(pt, 1.0)}
+    val data = d.map { pt => pointOps.vectorToPoint(pt)}
     data.setName("input to sample initializer")
     data.persist()
 

--- a/src/main/scala/com/massivedatascience/clusterer/SampleInitializer.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/SampleInitializer.scala
@@ -20,7 +20,6 @@ package com.massivedatascience.clusterer
 import org.apache.spark.SparkContext._
 import org.apache.spark.mllib.linalg.Vector
 import org.apache.spark.rdd.RDD
-import org.apache.spark.storage.StorageLevel
 
 class SampleInitializer(val assignments: RDD[Int]) extends KMeansInitializer {
   def init(
@@ -29,7 +28,7 @@ class SampleInitializer(val assignments: RDD[Int]) extends KMeansInitializer {
 
     val data = d.map {pt => pointOps.inhomogeneousToPoint(pt, 1.0)}
     data.setName("input to sample initializer")
-    data.persist(StorageLevel)
+    data.persist()
 
     val centroids = assignments.zip(data).aggregateByKey(pointOps.getCentroid)(
       (centroid, pt) => centroid.add(pt),

--- a/src/main/scala/com/massivedatascience/clusterer/SampleInitializer.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/SampleInitializer.scala
@@ -26,7 +26,7 @@ class SampleInitializer(val assignments: RDD[Int]) extends KMeansInitializer {
     pointOps: BregmanPointOps,
     d: RDD[Vector]): (RDD[BregmanPoint], Array[Array[BregmanCenter]]) = {
 
-    val data = d.map { pt => pointOps.vectorToPoint(pt)}
+    val data = d.map(pointOps.vectorToPoint)
     data.setName("input to sample initializer")
     data.persist()
 

--- a/src/main/scala/com/massivedatascience/clusterer/SampleInitializer.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/SampleInitializer.scala
@@ -29,7 +29,7 @@ class SampleInitializer(val assignments: RDD[Int]) extends KMeansInitializer {
 
     val data = d.map {pt => pointOps.inhomogeneousToPoint(pt, 1.0)}
     data.setName("input to sample initializer")
-    data.persist(StorageLevel.MEMORY_ONLY_SER)
+    data.persist(StorageLevel)
 
     val centroids = assignments.zip(data).aggregateByKey(pointOps.getCentroid)(
       (centroid, pt) => centroid.add(pt),

--- a/src/main/scala/com/massivedatascience/clusterer/TrackingKMeans.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/TrackingKMeans.scala
@@ -81,6 +81,12 @@ class TrackingKMeans(
   terminationCondition: TerminationCondition = DefaultTerminationCondition)
   extends MultiKMeansClusterer {
 
+  class NotSerializable {
+
+  }
+
+  val x = new NotSerializable
+
   /**
    *
    * @param center  the centroid of the cluster

--- a/src/main/scala/com/massivedatascience/clusterer/TrackingStats.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/TrackingStats.scala
@@ -23,20 +23,21 @@ import org.apache.spark.{Logging, SparkContext}
 
 
 class TrackingStats(sc: SparkContext, val round: Int) extends BasicStats with Serializable with Logging {
-  val newlyAssignedPoints = sc.accumulator[Int](0, s"Newly Assigned Points $round")
-  val reassignedPoints = sc.accumulator[Int](0, s"Reassigned Points $round")
-  val unassignedPoints = sc.accumulator[Int](0, s"Unassigned Points $round")
-  val improvement = sc.accumulator[Double](0.0, s"Improvement $round")
-  val relocatedCenters = sc.accumulator[Int](0, s"Relocated Centers $round")
-  val dirtyOther = sc.accumulator[Int](0, s"=> Other Moving $round")
-  val dirtySame = sc.accumulator[Int](0, s"=> Same Moving $round")
-  val stationary = sc.accumulator[Int](0, s"Stationary $round")
-  val closestClean = sc.accumulator[Int](0, s"Moving => Other Stationary $round")
-  val closestDirty = sc.accumulator[Int](0, s"Stationary => Other Moving $round")
-  val movement = sc.accumulator[Double](0.0, s"Center Movement $round")
-  val nonemptyClusters = sc.accumulator[Int](0, s"Non-Empty Clusters $round")
-  val emptyClusters = sc.accumulator[Int](0, s"Empty Clusters $round")
-  val largestCluster = sc.accumulator[Long](0, s"Largest Cluster $round")
+  val currentRound = sc.accumulator[Int](round, s"$round")
+  val newlyAssignedPoints = sc.accumulator[Int](0, s"Newly Assigned Points")
+  val reassignedPoints = sc.accumulator[Int](0, s"Reassigned Points")
+  val unassignedPoints = sc.accumulator[Int](0, s"Unassigned Points")
+  val improvement = sc.accumulator[Double](0.0, s"Improvement")
+  val relocatedCenters = sc.accumulator[Int](0, s"Relocated Centers")
+  val dirtyOther = sc.accumulator[Int](0, s"=> Other Moving")
+  val dirtySame = sc.accumulator[Int](0, s"=> Same Moving")
+  val stationary = sc.accumulator[Int](0, s"Stationary")
+  val closestClean = sc.accumulator[Int](0, s"Moving => Other Stationary")
+  val closestDirty = sc.accumulator[Int](0, s"Stationary => Other Moving")
+  val movement = sc.accumulator[Double](0.0, s"Center Movement")
+  val nonemptyClusters = sc.accumulator[Int](0, s"Non-Empty Clusters")
+  val emptyClusters = sc.accumulator[Int](0, s"Empty Clusters")
+  val largestCluster = sc.accumulator[Long](0, s"Largest Cluster")
 
   def getMovement = movement.value
 
@@ -47,7 +48,7 @@ class TrackingStats(sc: SparkContext, val round: Int) extends BasicStats with Se
   def getRound = round
 
   def report() = {
-    logInfo(s"round $round")
+    logInfo(s"round ${currentRound.value}")
     logInfo(s"relocated centers = ${relocatedCenters.value}")
     logInfo(s"lowered distortion by ${improvement.value}")
     logInfo(s"center movement by ${movement.value}")

--- a/src/main/scala/com/massivedatascience/clusterer/TrackingStats.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/TrackingStats.scala
@@ -22,18 +22,13 @@ import org.apache.spark.SparkContext._
 import org.apache.spark.{Logging, SparkContext}
 
 
-class TrackingStats(sc: SparkContext, val round: Int) extends BasicStats with Serializable with Logging {
-  val currentRound = sc.accumulator[Int](round, s"$round")
+class TrackingStats(sc: SparkContext) extends BasicStats with Serializable with Logging {
+  val currentRound = sc.accumulator[Int](-1, s"Round")
   val newlyAssignedPoints = sc.accumulator[Int](0, s"Newly Assigned Points")
   val reassignedPoints = sc.accumulator[Int](0, s"Reassigned Points")
   val unassignedPoints = sc.accumulator[Int](0, s"Unassigned Points")
   val improvement = sc.accumulator[Double](0.0, s"Improvement")
   val relocatedCenters = sc.accumulator[Int](0, s"Relocated Centers")
-  val dirtyOther = sc.accumulator[Int](0, s"=> Other Moving")
-  val dirtySame = sc.accumulator[Int](0, s"=> Same Moving")
-  val stationary = sc.accumulator[Int](0, s"Stationary")
-  val closestClean = sc.accumulator[Int](0, s"Moving => Other Stationary")
-  val closestDirty = sc.accumulator[Int](0, s"Stationary => Other Moving")
   val movement = sc.accumulator[Double](0.0, s"Center Movement")
   val nonemptyClusters = sc.accumulator[Int](0, s"Non-Empty Clusters")
   val emptyClusters = sc.accumulator[Int](0, s"Empty Clusters")
@@ -45,7 +40,7 @@ class TrackingStats(sc: SparkContext, val round: Int) extends BasicStats with Se
 
   def getEmptyClusters = emptyClusters.value
 
-  def getRound = round
+  def getRound = currentRound.value
 
   def report() = {
     logInfo(s"round ${currentRound.value}")
@@ -56,12 +51,6 @@ class TrackingStats(sc: SparkContext, val round: Int) extends BasicStats with Se
     logInfo(s"newly assigned points = ${newlyAssignedPoints.value}")
     logInfo(s"unassigned points = ${unassignedPoints.value}")
     logInfo(s"non-empty clusters = ${nonemptyClusters.value}")
-    logInfo(s"some other moving cluster is closest ${dirtyOther.value}")
-    logInfo(s"my cluster moved closest = ${dirtySame.value}")
-
-    logInfo(s"my stationary cluster is closest = ${stationary.value}")
-    logInfo(s"my cluster moved away and a stationary cluster is now closest = ${closestClean.value}")
-    logInfo(s"my cluster didn't move, but a moving cluster is closest = ${closestDirty.value}")
     logInfo(s"largest cluster size ${largestCluster.value}")
   }
 }

--- a/src/main/scala/com/massivedatascience/clusterer/WeightedVector.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/WeightedVector.scala
@@ -34,6 +34,7 @@ trait WeightedVector extends Serializable {
   override def toString: String = weight + "," + homogeneous.toString
 
   def asImmutable = new ImmutableHomogeneousVector(homogeneous, weight).asInstanceOf[WeightedVector]
+
 }
 
 trait MutableWeightedVector extends WeightedVector {
@@ -42,15 +43,20 @@ trait MutableWeightedVector extends WeightedVector {
   def sub(p: WeightedVector): this.type
 
   def asImmutable: WeightedVector
+
 }
 
 class ImmutableInhomogeneousVector(raw: Vector, val weight: Double) extends WeightedVector {
   override val inhomogeneous = raw
   override lazy val homogeneous = asHomogeneous
+
+  def copy = asImmutable
 }
 
 class ImmutableHomogeneousVector(raw: Vector, val weight: Double) extends WeightedVector {
   override lazy val inhomogeneous: Vector = asInhomogeneous
   override val homogeneous: Vector = raw
+
+  def copy = asImmutable
 }
 

--- a/src/main/scala/com/massivedatascience/clusterer/WeightedVector.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/WeightedVector.scala
@@ -27,13 +27,13 @@ trait WeightedVector extends Serializable {
 
   def homogeneous: Vector
 
-  def asInhomogeneous = clusterer.asInhomogeneous(homogeneous, weight)
+  def asInhomogeneous: Vector = clusterer.asInhomogeneous(homogeneous, weight)
 
-  def asHomogeneous = clusterer.asHomogeneous(inhomogeneous, weight)
+  def asHomogeneous: Vector = clusterer.asHomogeneous(inhomogeneous, weight)
 
   override def toString: String = weight + "," + homogeneous.toString
 
-  def asImmutable = new ImmutableHomogeneousVector(homogeneous, weight).asInstanceOf[WeightedVector]
+  def asImmutable: WeightedVector = new ImmutableHomogeneousVector(homogeneous, weight)
 
 }
 
@@ -44,21 +44,15 @@ trait MutableWeightedVector extends WeightedVector {
 
   def asImmutable: WeightedVector
 
-  def toArray = inhomogeneous.toArray
-
 }
 
 class ImmutableInhomogeneousVector(raw: Vector, val weight: Double) extends WeightedVector {
   override val inhomogeneous = raw
   override lazy val homogeneous = asHomogeneous
-
-  def copy = asImmutable
 }
 
 class ImmutableHomogeneousVector(raw: Vector, val weight: Double) extends WeightedVector {
   override lazy val inhomogeneous: Vector = asInhomogeneous
   override val homogeneous: Vector = raw
-
-  def copy = asImmutable
 }
 

--- a/src/main/scala/com/massivedatascience/clusterer/WeightedVector.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/WeightedVector.scala
@@ -33,7 +33,7 @@ trait WeightedVector extends Serializable {
 
   override def toString: String = weight + "," + homogeneous.toString
 
-  def asImmutable: WeightedVector = new ImmutableHomogeneousVector(homogeneous, weight)
+  def asImmutable: WeightedVector = new ImmutableHomogeneousVector(homogeneous.copy, weight)
 
 }
 

--- a/src/main/scala/com/massivedatascience/clusterer/WeightedVector.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/WeightedVector.scala
@@ -44,6 +44,8 @@ trait MutableWeightedVector extends WeightedVector {
 
   def asImmutable: WeightedVector
 
+  def toArray = inhomogeneous.toArray
+
 }
 
 class ImmutableInhomogeneousVector(raw: Vector, val weight: Double) extends WeightedVector {

--- a/src/main/scala/com/massivedatascience/clusterer/package.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/package.scala
@@ -71,22 +71,13 @@ package object clusterer {
 
     def distance(p: P, c: C): Double
 
-    /**
-     * convert a vector in homogeneous coordinates into a point
-     * @param v input vector
-     * @param weight weight of vector
-     * @return  weighted vector
-     */
-    def homogeneousToPoint(v: Vector, weight: Double): P
-
 
     /**
      * convert a vector in inhomogeneous coordinates into a point
      * @param v input vector
-     * @param weight weight of input vector
      * @return weighted vector
      */
-    def inhomogeneousToPoint(v: Vector, weight: Double): P
+    def vectorToPoint(v: Vector): P
 
     /**
      * converted a weighted vector to a point

--- a/src/main/scala/com/massivedatascience/clusterer/package.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/package.scala
@@ -38,7 +38,7 @@ package object clusterer {
 
   val Infinity = Double.MaxValue
   val Unknown = -1.0
-  val empty: Vector = new SparseVector(0, Array[Int](), Array[Double]())
+  val empty: Vector = new DenseVector(Array[Double]())
 
   def asInhomogeneous(homogeneous: Vector, weight: Double) = {
     val x = homogeneous.copy

--- a/src/main/scala/com/massivedatascience/clusterer/package.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/package.scala
@@ -165,8 +165,15 @@ package object clusterer {
    * @param weight weight of point
    * @param f f(point)
    */
-  class BregmanPoint(embedding: Vector, weight: Double, val f: Double)
-    extends ImmutableInhomogeneousVector(embedding, weight)
+  class BregmanPoint(
+    embedding: Vector,
+    val weight: Double,
+    val f: Double,
+    isHomogeneous: Boolean = false) extends WeightedVector {
+
+    override lazy val inhomogeneous = if (isHomogeneous) asInhomogeneous else embedding
+    override lazy val homogeneous = if (!isHomogeneous) asHomogeneous else embedding
+  }
 
   /**
    * A cluster center with an additional Double and an additional vector containing the gradient
@@ -177,8 +184,16 @@ package object clusterer {
    * @param dotGradMinusF  center dot gradient(center) - f(center)
    * @param gradient gradient of center
    */
-  class BregmanCenter(h: Vector, weight: Double, val dotGradMinusF: Double, val gradient: Vector)
-    extends ImmutableHomogeneousVector(h, weight)
+  class BregmanCenter(
+    h: Vector,
+    val weight: Double,
+    val dotGradMinusF: Double,
+    val gradient: Vector,
+    isHomogeneous: Boolean = true) extends WeightedVector {
+
+    override lazy val inhomogeneous = if (isHomogeneous) asInhomogeneous else h
+    override lazy val homogeneous = if (!isHomogeneous) asHomogeneous else h
+  }
 
   trait BregmanPointOps extends PointOps[BregmanPoint, BregmanCenter]
 }

--- a/src/main/scala/com/massivedatascience/clusterer/package.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/package.scala
@@ -38,7 +38,7 @@ package object clusterer {
 
   val Infinity = Double.MaxValue
   val Unknown = -1.0
-  val empty: Vector = new DenseVector(Array[Double]())
+  val empty: DenseVector = new DenseVector(Array[Double]())
 
   def asInhomogeneous(homogeneous: Vector, weight: Double) = {
     val x = homogeneous.copy

--- a/src/main/scala/com/massivedatascience/clusterer/package.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/package.scala
@@ -24,18 +24,6 @@ import org.apache.spark.rdd.RDD
 
 package object clusterer {
 
-
-  def preview[T](data: RDD[T], header: String = ""): RDD[T] = {
-    if (data.sparkContext.getConf.getBoolean("com.massivedatascience.clusterer.preview",
-      defaultValue=false)) {
-      println(header)
-      val head = data.take(10)
-      head.map(println)
-    }
-    data
-  }
-
-
   val Infinity = Double.MaxValue
   val Unknown = -1.0
   val empty: DenseVector = new DenseVector(Array[Double]())

--- a/src/main/scala/com/massivedatascience/clusterer/util/BLAS.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/util/BLAS.scala
@@ -356,7 +356,7 @@ object BLAS extends Serializable {
           case sx: SparseVector =>
             dot(sx, dy)
           case dx: DenseVector =>
-            dot(dx, dy)
+            denseDot(dx, dy)
           case _ =>
             throw new UnsupportedOperationException(
               s"sum doesn't support x type ${x.getClass}.")
@@ -378,6 +378,7 @@ object BLAS extends Serializable {
   /**
    * dot(x, y)
    */
+  @inline
   private def denseDot(x: DenseVector, y: DenseVector): Double = {
     val n = x.size
     f2jBLAS.ddot(n, x.values, 1, y.values, 1)
@@ -386,6 +387,7 @@ object BLAS extends Serializable {
   /**
    * dot(x, y)
    */
+
   private def dot(x: SparseVector, y: DenseVector): Double = {
     val nnz = x.indices.size
     var sum = 0.0

--- a/src/main/scala/com/massivedatascience/clusterer/util/BLAS.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/util/BLAS.scala
@@ -346,21 +346,32 @@ object BLAS extends Serializable {
    * dot(x, y)
    */
   def dot(x: Vector, y: Vector): Double = {
-    if( x.size != y.size ) {
+    if (x.size != y.size) {
       require(x.size == y.size, s"${x.size} vs ${y.size}")
     }
 
-    if (x.isInstanceOf[DenseVector] && y.isInstanceOf[DenseVector])
-      denseDot(x.asInstanceOf[DenseVector], y.asInstanceOf[DenseVector])
-    else (x, y) match {
-      case (sx: SparseVector, dy: DenseVector) =>
-        dot(sx, dy)
-      case (dx: DenseVector, sy: SparseVector) =>
-        dot(sy, dx)
-      case (sx: SparseVector, sy: SparseVector) =>
-        dot(sx, sy)
-      case _ =>
-        throw new IllegalArgumentException(s"dot doesn't support (${x.getClass}, ${y.getClass}).")
+    y match {
+      case dy: DenseVector =>
+        x match {
+          case sx: SparseVector =>
+            dot(sx, dy)
+          case dx: DenseVector =>
+            dot(dx, dy)
+          case _ =>
+            throw new UnsupportedOperationException(
+              s"sum doesn't support x type ${x.getClass}.")
+        }
+      case sy: SparseVector =>
+        x match {
+          case sx: SparseVector =>
+            dot(sx, sy)
+          case dx: DenseVector =>
+            dot(new SparseVector(dx.size, (0 until dx.size).toArray, dx.values), sy)
+          case _ =>
+            throw new UnsupportedOperationException(
+              s"sum doesn't support x type ${x.getClass}.")
+
+        }
     }
   }
 

--- a/src/main/scala/com/massivedatascience/clusterer/util/BLAS.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/util/BLAS.scala
@@ -349,9 +349,10 @@ object BLAS extends Serializable {
     if( x.size != y.size ) {
       require(x.size == y.size, s"${x.size} vs ${y.size}")
     }
-    (x, y) match {
-      case (dx: DenseVector, dy: DenseVector) =>
-        dot(dx, dy)
+
+    if (x.isInstanceOf[DenseVector] && y.isInstanceOf[DenseVector])
+      denseDot(x.asInstanceOf[DenseVector], y.asInstanceOf[DenseVector])
+    else (x, y) match {
       case (sx: SparseVector, dy: DenseVector) =>
         dot(sx, dy)
       case (dx: DenseVector, sy: SparseVector) =>
@@ -366,7 +367,7 @@ object BLAS extends Serializable {
   /**
    * dot(x, y)
    */
-  private def dot(x: DenseVector, y: DenseVector): Double = {
+  private def denseDot(x: DenseVector, y: DenseVector): Double = {
     val n = x.size
     f2jBLAS.ddot(n, x.values, 1, y.values, 1)
   }

--- a/src/main/scala/com/massivedatascience/clusterer/util/BLAS.scala
+++ b/src/main/scala/com/massivedatascience/clusterer/util/BLAS.scala
@@ -52,7 +52,7 @@ object BLAS extends Serializable {
           case sx: SparseVector =>
             axpy(a, sx, dy)
           case dx: DenseVector =>
-            axpy(a, dx, dy)
+            denseAxpy(a, dx, dy)
           case _ =>
             throw new UnsupportedOperationException(
               s"axpy doesn't support x type ${x.getClass}.")
@@ -315,7 +315,7 @@ object BLAS extends Serializable {
   /**
    * y += a * x
    */
-  private def axpy(a: Double, x: DenseVector, y: DenseVector): Vector = {
+  def denseAxpy(a: Double, x: DenseVector, y: DenseVector): Vector = {
     val n = x.size
     f2jBLAS.daxpy(n, a, x.values, 1, y.values, 1)
     y

--- a/src/test/scala/com/massivedatascience/clusterer/KMeansSuite.scala
+++ b/src/test/scala/com/massivedatascience/clusterer/KMeansSuite.scala
@@ -44,26 +44,29 @@ class KMeansSuite extends FunSuite with LocalSparkContext {
     // No matter how many runs or iterations we use, we should get one cluster,
     // centered at the mean of the points
 
-    //var model = KMeans.train(data, k = 1, maxIterations = 1, kMeansImplName = "COLUMN_TRACKING")
-    //assert(model.clusterCenters.head ~== center absTol 1E-5)
+    var
 
-    //model = KMeans.train(data, k = 1, maxIterations = 2, kMeansImplName = "COLUMN_TRACKING")
-    //assert(model.clusterCenters.head ~== center absTol 1E-5)
+    /* model = KMeans.train(data, k = 1, maxIterations = 1, kMeansImplName = "COLUMN_TRACKING")
+    assert(model.clusterCenters.head ~== center absTol 1E-5)
 
-    // model = KMeans.train(data, k = 1, maxIterations = 5, kMeansImplName = "COLUMN_TRACKING")
-    //assert(model.clusterCenters.head ~== center absTol 1E-5)
+    model = KMeans.train(data, k = 1, maxIterations = 2, kMeansImplName = "COLUMN_TRACKING")
+    assert(model.clusterCenters.head ~== center absTol 1E-5)
 
-    // model = KMeans.train(data, k = 1, maxIterations = 1, runs = 5, kMeansImplName = "COLUMN_TRACKING")
-    //assert(model.clusterCenters.head ~== center absTol 1E-5)
+    model = KMeans.train(data, k = 1, maxIterations = 5, kMeansImplName = "COLUMN_TRACKING")
+    assert(model.clusterCenters.head ~== center absTol 1E-5)
 
-    //model = KMeans.train(data, k = 1, maxIterations = 1, runs = 5, kMeansImplName = "COLUMN_TRACKING")
-    //assert(model.clusterCenters.head ~== center absTol 1E-5)
+    model = KMeans.train(data, k = 1, maxIterations = 1, runs = 5, kMeansImplName = "COLUMN_TRACKING")
+    assert(model.clusterCenters.head ~== center absTol 1E-5)
 
-    var model = KMeans.train(data, k = 1, maxIterations = 1, runs = 1, mode = RANDOM, kMeansImplName = "COLUMN_TRACKING")
+    model = KMeans.train(data, k = 1, maxIterations = 1, runs = 5, kMeansImplName = "COLUMN_TRACKING")
+    assert(model.clusterCenters.head ~== center absTol 1E-5)
+    */
+
+    model = KMeans.train(data, k = 1, maxIterations = 1, runs = 1, mode = RANDOM, kMeansImplName = "COLUMN_TRACKING")
     assert(model.clusterCenters.head ~== center absTol 1E-5)
 
     model = KMeans.train(
-      data, k = 1, maxIterations = 1, runs = 1, mode = K_MEANS_PARALLEL, kMeansImplName = "TRACKING")
+      data, k = 1, maxIterations = 1, runs = 1, mode = K_MEANS_PARALLEL, kMeansImplName = "COLUMN_TRACKING")
     assert(model.clusterCenters.head ~== center absTol 1E-5)
   }
 

--- a/src/test/scala/com/massivedatascience/clusterer/KMeansSuite.scala
+++ b/src/test/scala/com/massivedatascience/clusterer/KMeansSuite.scala
@@ -46,27 +46,27 @@ class KMeansSuite extends FunSuite with LocalSparkContext {
 
     var
 
-    /* model = KMeans.train(data, k = 1, maxIterations = 1, kMeansImplName = "COLUMN_TRACKING")
+    model = KMeans.train(data, k = 1, maxIterations = 1)
     assert(model.clusterCenters.head ~== center absTol 1E-5)
 
-    model = KMeans.train(data, k = 1, maxIterations = 2, kMeansImplName = "COLUMN_TRACKING")
+    model = KMeans.train(data, k = 1, maxIterations = 2)
     assert(model.clusterCenters.head ~== center absTol 1E-5)
 
-    model = KMeans.train(data, k = 1, maxIterations = 5, kMeansImplName = "COLUMN_TRACKING")
+    model = KMeans.train(data, k = 1, maxIterations = 5)
     assert(model.clusterCenters.head ~== center absTol 1E-5)
 
-    model = KMeans.train(data, k = 1, maxIterations = 1, runs = 5, kMeansImplName = "COLUMN_TRACKING")
+    model = KMeans.train(data, k = 1, maxIterations = 1, runs = 5)
     assert(model.clusterCenters.head ~== center absTol 1E-5)
 
-    model = KMeans.train(data, k = 1, maxIterations = 1, runs = 5, kMeansImplName = "COLUMN_TRACKING")
+    model = KMeans.train(data, k = 1, maxIterations = 1, runs = 5)
     assert(model.clusterCenters.head ~== center absTol 1E-5)
-    */
 
-    model = KMeans.train(data, k = 1, maxIterations = 1, runs = 1, mode = RANDOM, kMeansImplName = "COLUMN_TRACKING")
+
+    model = KMeans.train(data, k = 1, maxIterations = 1, runs = 1, mode = RANDOM)
     assert(model.clusterCenters.head ~== center absTol 1E-5)
 
     model = KMeans.train(
-      data, k = 1, maxIterations = 1, runs = 1, mode = K_MEANS_PARALLEL, kMeansImplName = "COLUMN_TRACKING")
+      data, k = 1, maxIterations = 1, runs = 1, mode = K_MEANS_PARALLEL)
     assert(model.clusterCenters.head ~== center absTol 1E-5)
   }
 

--- a/src/test/scala/com/massivedatascience/clusterer/KMeansSuite.scala
+++ b/src/test/scala/com/massivedatascience/clusterer/KMeansSuite.scala
@@ -44,26 +44,26 @@ class KMeansSuite extends FunSuite with LocalSparkContext {
     // No matter how many runs or iterations we use, we should get one cluster,
     // centered at the mean of the points
 
-    var model = KMeans.train(data, k = 1, maxIterations = 1)
-    assert(model.clusterCenters.head ~== center absTol 1E-5)
+    //var model = KMeans.train(data, k = 1, maxIterations = 1, kMeansImplName = "COLUMN_TRACKING")
+    //assert(model.clusterCenters.head ~== center absTol 1E-5)
 
-    model = KMeans.train(data, k = 1, maxIterations = 2)
-    assert(model.clusterCenters.head ~== center absTol 1E-5)
+    //model = KMeans.train(data, k = 1, maxIterations = 2, kMeansImplName = "COLUMN_TRACKING")
+    //assert(model.clusterCenters.head ~== center absTol 1E-5)
 
-    model = KMeans.train(data, k = 1, maxIterations = 5)
-    assert(model.clusterCenters.head ~== center absTol 1E-5)
+    // model = KMeans.train(data, k = 1, maxIterations = 5, kMeansImplName = "COLUMN_TRACKING")
+    //assert(model.clusterCenters.head ~== center absTol 1E-5)
 
-    model = KMeans.train(data, k = 1, maxIterations = 1, runs = 5)
-    assert(model.clusterCenters.head ~== center absTol 1E-5)
+    // model = KMeans.train(data, k = 1, maxIterations = 1, runs = 5, kMeansImplName = "COLUMN_TRACKING")
+    //assert(model.clusterCenters.head ~== center absTol 1E-5)
 
-    model = KMeans.train(data, k = 1, maxIterations = 1, runs = 5)
-    assert(model.clusterCenters.head ~== center absTol 1E-5)
+    //model = KMeans.train(data, k = 1, maxIterations = 1, runs = 5, kMeansImplName = "COLUMN_TRACKING")
+    //assert(model.clusterCenters.head ~== center absTol 1E-5)
 
-    model = KMeans.train(data, k = 1, maxIterations = 1, runs = 1, mode = RANDOM)
+    var model = KMeans.train(data, k = 1, maxIterations = 1, runs = 1, mode = RANDOM, kMeansImplName = "COLUMN_TRACKING")
     assert(model.clusterCenters.head ~== center absTol 1E-5)
 
     model = KMeans.train(
-      data, k = 1, maxIterations = 1, runs = 1, mode = K_MEANS_PARALLEL)
+      data, k = 1, maxIterations = 1, runs = 1, mode = K_MEANS_PARALLEL, kMeansImplName = "TRACKING")
     assert(model.clusterCenters.head ~== center absTol 1E-5)
   }
 

--- a/src/test/scala/com/massivedatascience/clusterer/KMeansSuite.scala
+++ b/src/test/scala/com/massivedatascience/clusterer/KMeansSuite.scala
@@ -61,7 +61,6 @@ class KMeansSuite extends FunSuite with LocalSparkContext {
     model = KMeans.train(data, k = 1, maxIterations = 1, runs = 5)
     assert(model.clusterCenters.head ~== center absTol 1E-5)
 
-
     model = KMeans.train(data, k = 1, maxIterations = 1, runs = 1, mode = RANDOM)
     assert(model.clusterCenters.head ~== center absTol 1E-5)
 


### PR DESCRIPTION
Fixed caching policies. Now most data is cached in memory. 
Pull some data into memory explicitly by calling rdd.count().  This avoids expensive re-computation.
Lowered cost of computing new cluster centers.
Added parallel collections operations to speed up KMeansPlusPlus.
Fixed potential issue in identifying empty cluster.
Added assertions to insure that certain data in cached prior to use.
Eliminated sparse centroids because they are too slow.  If you need to operate on high dimensional sparse data, embed it in a low dimensional dense space.
