### PR TITLE
README: clarify squared Euclidean example of Bregman divergence

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ trait BregmanDivergence {
 
 ```
 
-For example, by defining ```convex``` to be the vector norm (i.e. the sum of the squares of the
-coordinates), one gets a distance function that equals the square of the well known Euclidean
+For example, by defining ```convex``` to be the squared vector norm (i.e. the sum of the squares of
+the coordinates), one gets a distance function that equals the square of the well known Euclidean
 distance. We name it the ```SquaredEuclideanDistanceDivergence```.
 
 In addition to the squared Euclidean distance function, this implementation provides several


### PR DESCRIPTION
this one was confusing, since *the vector norm* is not *the sum of the squares of the coordinates* and the non-squared Euclidean norm doesn't satisfy the differentiability needed to construct a Bregman divergence.